### PR TITLE
Исправление работы generateRequestNumber

### DIFF
--- a/Api/X/Request.php
+++ b/Api/X/Request.php
@@ -52,6 +52,6 @@ abstract class Request extends XmlRequest
      */
     protected function generateRequestNumber()
     {
-        return str_replace('.', '', microtime(true));
+        return str_pad(str_replace('.', '', microtime(true)), 14, 0);
     }
 }


### PR DESCRIPTION
Хитрый вариант уникального requestId не настолько хорош на практике. В результате выполнения microtime иногда дробное число с 3 или даже 4 цифрами после точки (и из-за этого итоговый номер запроса получался на порядок или на два больше). На что WM отвечает: «не выполнено условие постоянного увеличения значения параметра w3s.request/reqn».

Отказываться от microtime сейчас не вариант, потому что всем, кто использует библиотеку придётся писать в саппорт для сброса счетчика запросов.

Придумал другое решение.
