### PR TITLE
Light (Certificate) Auth

### DIFF
--- a/Api/X/Request.php
+++ b/Api/X/Request.php
@@ -18,10 +18,26 @@ abstract class Request extends XmlRequest
     /** @var string reqn */
     protected $requestNumber;
 
+    /** @var string Light auth cert file name (PEM) */
+    protected $lightCert;
+
+    /** @var string Light auth key file name (PEM) */
+    protected $lightKey;
+
     public function __construct($authType = self::AUTH_CLASSIC)
     {
         $this->authType = $authType;
         $this->requestNumber = $this->generateRequestNumber();
+    }
+
+    /**
+     * @param string $lightCert Light auth cert file name (PEM)
+     * @param string $lightKey Light auth key file name (PEM)
+     */
+    public function cert($lightCert, $lightKey)
+    {
+        $this->lightCert = $lightCert;
+        $this->lightKey = $lightKey;
     }
 
     /**
@@ -30,6 +46,22 @@ abstract class Request extends XmlRequest
     public function getAuthType()
     {
         return $this->authType;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLightCert()
+    {
+        return $this->lightCert;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLightKey()
+    {
+        return $this->lightKey;
     }
 
     /**

--- a/Request/Requester/CurlRequester.php
+++ b/Request/Requester/CurlRequester.php
@@ -5,6 +5,7 @@ namespace baibaratsky\WebMoney\Request\Requester;
 use baibaratsky\WebMoney\Request\AbstractRequest;
 use baibaratsky\WebMoney\Request\XmlRequest;
 use baibaratsky\WebMoney\Exception\RequesterException;
+use baibaratsky\WebMoney\Api\X\Request;
 
 class CurlRequester extends AbstractRequester
 {
@@ -32,6 +33,10 @@ class CurlRequester extends AbstractRequester
         }
         curl_setopt($handler, CURLOPT_SSL_VERIFYPEER, $this->verifyCertificate);
         curl_setopt($handler, CURLOPT_SSLVERSION, 1);
+        if ($request instanceof Request && $request->getAuthType() === Request::AUTH_LIGHT) {
+            curl_setopt($handler, CURLOPT_SSLCERT, $request->getLightCert());
+            curl_setopt($handler, CURLOPT_SSLKEY, $request->getLightKey());
+        }
 
         ob_start();
         if (!curl_exec($handler)) {


### PR DESCRIPTION
$lightCert и $lightKey не стал добавлять в конструктор т.к. для этого нужно исправить все дочерние классы. Сделал новый метод cert() по аналогии с методом sign().