### PR TITLE
X2: onlyAuth bool to int conversion for xml

### DIFF
--- a/Api/X/X2/Request.php
+++ b/Api/X/X2/Request.php
@@ -38,8 +38,8 @@ class Request extends X\Request
     /** @var int trans/wminvid */
     protected $invoiceId;
 
-    /** @var string trans/onlyauth */
-    protected $onlyAuth = 1;
+    /** @var boolean trans/onlyauth */
+    protected $onlyAuth = true;
 
     /**
      * @param string $authType
@@ -98,7 +98,7 @@ class Request extends X\Request
         $xml .= self::xmlElement('pcode', $this->protectionCode);
         $xml .= self::xmlElement('desc', $this->description);
         $xml .= self::xmlElement('wminvid', $this->invoiceId);
-        $xml .= self::xmlElement('onlyauth', $this->onlyAuth);
+        $xml .= self::xmlElement('onlyauth', (int)$this->onlyAuth);
         $xml .= '</trans>';
         $xml .= '</w3s.request>';
 


### PR DESCRIPTION
Есил вызвать setOnlyAuth(true), то в $onlyAuth запишется bool, который потом в getData() выведется как 'true', а интерфейс принимает int.