### PR TITLE
X2: desc is optional

### DIFF
--- a/Api/X/X2/Request.php
+++ b/Api/X/X2/Request.php
@@ -72,7 +72,7 @@ class Request extends X\Request
         return array(
                 RequestValidator::TYPE_REQUIRED => array(
                         'transactionExternalId', 'payerPurse', 'payeePurse', 'amount',
-                        'description', 'invoiceId', 'onlyAuth',
+                        'invoiceId', 'onlyAuth',
                 ),
                 RequestValidator::TYPE_DEPEND_REQUIRED => array(
                         'signerWmid' => array('authType' => array(self::AUTH_CLASSIC)),


### PR DESCRIPTION
Если в X2 передать wminvid (setInvoiceId), тогда в description транзакции дописывается description из invoice (они конкатенируются). X2 можно вызывать и без description. Тогда если указываем wminvid в description транзакции попадает description из invoice, если не указываем wminvid тогда в description транзакции будет пусто, но транзакция все-же выполнится.